### PR TITLE
Updated gemini image response model

### DIFF
--- a/tle/cogs/acd_ai.py
+++ b/tle/cogs/acd_ai.py
@@ -38,7 +38,7 @@ class ACD_AI(commands.Cog):
                               safety_settings=settings.text_safety_settings)
         
         '''gemini model for image inputs'''
-        self.image_model = genai.GenerativeModel(model_name="gemini-pro-vision",
+        self.image_model = genai.GenerativeModel(model_name="gemini-1.5-flash",
                               generation_config=settings.image_generation_config, 
                               safety_settings=settings.image_safety_settings)
         


### PR DESCRIPTION
Updated gemini-pro-vision model to gemini-1.5-flash as gemini-pro-vision model will be deprecated after july 12, 2024.
have done the necessary testings, please review and merge.

![Screenshot 2024-06-13 154002](https://github.com/ACodeDaily/TLE-ACodeDaily/assets/122669445/95cb33c4-06f6-4b74-9740-453a06fdc711)
